### PR TITLE
remove postgres connection and npm watch command from server startup

### DIFF
--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -10,8 +10,7 @@ config :wwm, WwmWeb.Endpoint,
   http: [port: 4000],
   debug_errors: true,
   code_reloader: true,
-  check_origin: false,
-  watchers: [npm: ["run", "watch", cd: Path.expand("../assets", __DIR__)]]
+  check_origin: false
 
 # ## SSL Support
 #

--- a/elixir/lib/application.ex
+++ b/elixir/lib/application.ex
@@ -15,8 +15,6 @@ defmodule Wwm.Application do
 
     # Define workers and child supervisors to be supervised
     children = [
-      # Start the Ecto repository
-      supervisor(Wwm.Repo, []),
       # Start the endpoint when the application starts
       supervisor(WwmWeb.Endpoint, []),
       # Start your own worker by calling: Wwm.Worker.start_link(arg1, arg2, arg3)


### PR DESCRIPTION
this removes PG / trying-to-call-webpack-from-cmd-line errors from server startup. 