### PR TITLE
Fill out javascript Client methods

### DIFF
--- a/client/chrome-extension/.eslintrc
+++ b/client/chrome-extension/.eslintrc
@@ -8,7 +8,9 @@
     "describe": true,
     "it": true,
     "beforeEach": true,
-    "afterEach": true
+    "afterEach": true,
+    "before": true,
+    "after": true
   },
 
   "rules": {

--- a/client/chrome-extension/src/client/Client.js
+++ b/client/chrome-extension/src/client/Client.js
@@ -48,6 +48,15 @@ class Client {
           });
         }
       }
+      // detect pause events
+      if (state.last_action.type === 'pause') {
+        if (this.onPauseCallback) {
+          this.onPauseCallback({
+            videoTime: state.last_action.video_time,
+            worldTime: state.last_action.world_time,
+          });
+        }
+      }
       this.prevState = state;
     });
   }
@@ -77,6 +86,11 @@ class Client {
   async disconnectSync() {
     await new Promise(resolve => this.disconnect(resolve));
   }
+  resetCallbacks() {
+    this.onUserJoin();
+    this.onPlay();
+    this.onPause();
+  }
   onUserJoin(callback) {
     this.onUserJoinCallback = callback;
   }
@@ -89,6 +103,16 @@ class Client {
   }
   onPlay(callback) {
     this.onPlayCallback = callback;
+  }
+  pause(videoTime) {
+    this.channel.push('action', {
+      type: 'pause',
+      video_time: videoTime,
+      world_time: Date.now(),
+    });
+  }
+  onPause(callback) {
+    this.onPauseCallback = callback;
   }
 }
 

--- a/client/chrome-extension/src/client/Client.js
+++ b/client/chrome-extension/src/client/Client.js
@@ -61,7 +61,7 @@ class Client {
     });
   }
   get connected() {
-    return this.socket.isConnected();
+    return this.socket && this.socket.isConnected();
   }
   async connectSync() {
     await new Promise((resolve) => {

--- a/client/chrome-extension/src/client/Client.js
+++ b/client/chrome-extension/src/client/Client.js
@@ -23,6 +23,13 @@ class Client {
       .receive('ok', onSuccess)
       .receive('error', onError);
   }
+  disconnect(onSuccess) {
+    this.channel.leave().receive('ok', () => {
+      this.socket.disconnect(() => {
+        onSuccess();
+      });
+    });
+  }
 }
 
 export default Client;

--- a/client/chrome-extension/src/client/MockClient.js
+++ b/client/chrome-extension/src/client/MockClient.js
@@ -38,6 +38,19 @@ class MockClient {
   onUserJoin(callback) {
     console.log('MockClient::onUserJoin called with:', { callback: typeof callback });
   }
+  play(videoTime) {
+    console.log('MockClient::play called with:', { videoTime });
+  }
+  onPlay(callback) {
+    console.log('MockClient::onPlay called with:', { callback: typeof callback });
+  }
+  pause(videoTime) {
+    console.log('MockClient::pause called with:', { videoTime });
+  }
+  onPause(callback) {
+    console.log('MockClient::onPause called with:', { callback: typeof callback });
+  }
+  resetCallbacks() {}
 }
 
 export default MockClient;

--- a/client/chrome-extension/src/client/MockClient.js
+++ b/client/chrome-extension/src/client/MockClient.js
@@ -30,6 +30,9 @@ class MockClient {
   connect(onSuccess, onError) {
     console.log('MockClient::connect called with:', { onSuccess: typeof onSuccess, onError: typeof onError });
   }
+  disconnect(onSuccess) {
+    console.log('MockClient::disconnect called with:', { onSuccess: typeof onSuccess });
+  }
 }
 
 export default MockClient;

--- a/client/chrome-extension/src/client/MockClient.js
+++ b/client/chrome-extension/src/client/MockClient.js
@@ -30,8 +30,13 @@ class MockClient {
   connect(onSuccess, onError) {
     console.log('MockClient::connect called with:', { onSuccess: typeof onSuccess, onError: typeof onError });
   }
+  connectSync() {}
   disconnect(onSuccess) {
     console.log('MockClient::disconnect called with:', { onSuccess: typeof onSuccess });
+  }
+  disconnectSync() {}
+  onUserJoin(callback) {
+    console.log('MockClient::onUserJoin called with:', { callback: typeof callback });
   }
 }
 

--- a/client/chrome-extension/src/test/IntegrationTest.js
+++ b/client/chrome-extension/src/test/IntegrationTest.js
@@ -119,9 +119,7 @@ describe('integration between server and client', () => {
         client1 = new Client('ws://localhost:4000/socket', 'user1');
         client2 = new Client('ws://localhost:4000/socket', 'user2');
         await client1.connectSync();
-        // reset callbacks
-        client1.onUserJoin();
-        client1.onPlay();
+        client1.resetCallbacks();
       });
       after(async () => {
         await client1.disconnectSync();
@@ -142,9 +140,8 @@ describe('integration between server and client', () => {
       before(async () => {
         await client1.connectSync();
         await client2.connectSync();
-        // reset callbacks
-        client1.onUserJoin();
-        client1.onPlay();
+        client1.resetCallbacks();
+        client2.resetCallbacks();
       });
       after(async () => {
         await client1.disconnectSync();
@@ -158,7 +155,17 @@ describe('integration between server and client', () => {
           expect(worldTime).to.be.above(0);
           done();
         });
-        client1.play(expectedVideoTime);
+        client2.play(expectedVideoTime);
+      });
+      it('can detect another client\'s pause message', (done) => {
+        const expectedVideoTime = 1234;
+        client1.onPause(({ videoTime, worldTime }) => {
+          expect(videoTime).to.equal(expectedVideoTime);
+          expect(worldTime).to.be.a('number');
+          expect(worldTime).to.be.above(0);
+          done();
+        });
+        client2.pause(expectedVideoTime);
       });
     });
   });

--- a/client/chrome-extension/src/test/IntegrationTest.js
+++ b/client/chrome-extension/src/test/IntegrationTest.js
@@ -78,20 +78,23 @@ describe('integration between server and client', () => {
     });
   });
 
-  describe('the client', function () {
+  describe('one client', function () {
     this.timeout(20000);
-    let serverProcess;
-    beforeEach(async () => {
+    let serverProcess, client;
+    before(async () => {
       serverProcess = await startServer();
     });
-    afterEach(async () => {
+    after(async () => {
       await killServer(serverProcess);
     });
     it('can make a connection', async () => {
-      const client = new Client('ws://localhost:4000/socket', 'user');
+      client = new Client('ws://localhost:4000/socket', 'user');
       await new Promise((resolve, reject) => {
         client.connect(resolve, reject);
       });
+    });
+    it('can disconnect', async (done) => {
+      client.disconnect(done);
     });
   });
 });


### PR DESCRIPTION
This PR fleshes out (maybe all necessary?) Client functionality.
The javascript client for our server now supports the following functions:
- connect()
- disconnect()
- onUserJoin()
- play()
- onPlay()
- pause()
- onPause()

play() and pause() send the appropriate action events to the server. onUserJoin(), onPlay(), and onPause() take in callbacks that get called when those events are detected from the server. 

Check out IntegrationTest.js for proof of the functionality! It spins up the actual server and pokes it with the client. (Also it's great that the server can spin up so quickly)