### PR TITLE
increase server start / stop integration test timeout

### DIFF
--- a/client/chrome-extension/src/test/IntegrationTest.js
+++ b/client/chrome-extension/src/test/IntegrationTest.js
@@ -83,7 +83,7 @@ describe('integration between server and client', () => {
     });
     describe('the server', () => {
       it('can start and stop', async function () {
-        this.timeout(20000);
+        this.timeout(60000);
         const serverProcess = await startServer();
         await killServer(serverProcess);
       });


### PR DESCRIPTION
Addresses symptom of #55, although still unsure:
* why that test is taking so long
* why that test and those around it show a duration in the console after running:
```
      the server
        ✓ can start and stop (19566ms)
```
but the tests that actually test interaction and behavior don't:
```
      with both connected
        ✓ can detect another client's play message
        ✓ can detect another client's pause message
```
* why the test output has that big ugly uncaught error stacktrace that begins:
```
Error: Uncaught [Error: Could not connect: [object Event]]
    at reportException (/home/travis/build/SylverStudios/WatchWithMe/client/chrome-extension/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
    at invokeEventListeners (/home/travis/build/SylverStudios/WatchWithMe/client/chrome-extension/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:209:9)
```
is this benign? or obscuring an actual test failure / lack of test coverage?