### PR TITLE
Pass the username on js socket connect

### DIFF
--- a/client/chrome-extension/src/client/Client.js
+++ b/client/chrome-extension/src/client/Client.js
@@ -10,6 +10,7 @@ class Client {
 
     this.socket = new Socket(address, {
       reconnectAfterMs: () => 500,
+      params: { username: username }
     });
   }
   connect(onSuccess, onError) {

--- a/fjord/lib/fjord_web/channels/room_channel.ex
+++ b/fjord/lib/fjord_web/channels/room_channel.ex
@@ -3,6 +3,7 @@ defmodule FjordWeb.RoomChannel do
   require Logger
   alias Fjord.Cache
   alias Fjord.Cache.{Action, Video}
+
   @moduledoc """
   As far as I can tell, each socket that connects to this channel (room:*)
   will have a separate process waiting to call these functions.
@@ -28,9 +29,9 @@ defmodule FjordWeb.RoomChannel do
       - *time    => millisecond timestamp
   """
 
-  intercept ["new_msg"]
+  intercept(["new_msg"])
 
-  def join("room:lobby", _message, socket) do
+  def join("room:lobby", message, socket) do
     send(self(), :after_join)
     {:ok, socket}
   end
@@ -39,9 +40,8 @@ defmodule FjordWeb.RoomChannel do
     {:error, %{reason: "unauthorized"}}
   end
 
-# Update state and broadcast it, no validate because we know it's a join
+  # Update state and broadcast it, no validate because we know it's a join
   def handle_info(:after_join, socket) do
-
     :join
     |> Action.create(socket.assigns.username)
     |> update_and_broadcast(socket)
@@ -49,24 +49,32 @@ defmodule FjordWeb.RoomChannel do
     {:noreply, socket}
   end
 
-# HANDLE IN
+  # HANDLE IN
 
-# handle_in take the event type, the message, and the socket
+  # handle_in take the event type, the message, and the socket
   def handle_in("new_msg", %{"body" => body}, socket) do
-    message_event = %{sender: socket.assigns.username, body: "[#{socket.assigns.username}] #{body}"}
-    broadcast! socket, "new_msg", message_event
+    message_event = %{
+      sender: socket.assigns.username,
+      body: "[#{socket.assigns.username}] #{body}"
+    }
+
+    broadcast!(socket, "new_msg", message_event)
     {:reply, {:ok, message_event}, socket}
   end
 
   def handle_in("heartbeat", %{"video_time" => v_time, "world_time" => w_time}, socket) do
-    Logger.debug fn ->
+    Logger.debug(fn ->
       "Good to know #{socket.assigns.username}'s video is at #{v_time}, as of #{w_time}"
-    end
+    end)
+
     {:reply, :ok, socket}
   end
 
-  def handle_in("action", %{"type" => type, "video_time" => v_time, "world_time" => w_time}, socket) do
-
+  def handle_in(
+        "action",
+        %{"type" => type, "video_time" => v_time, "world_time" => w_time},
+        socket
+      ) do
     case Action.decode_type(type) do
       {:ok, atom_type} ->
         atom_type
@@ -88,14 +96,14 @@ defmodule FjordWeb.RoomChannel do
     if socket.assigns.username === payload.sender do
       {:noreply, socket}
     else
-      push socket, "new_msg", payload
+      push(socket, "new_msg", payload)
       {:noreply, socket}
     end
   end
 
   # Private convenience methods
   defp broadcast_and_return(video_state, socket) do
-    broadcast! socket, "state_change", video_state
+    broadcast!(socket, "state_change", video_state)
     video_state
   end
 

--- a/fjord/lib/fjord_web/channels/user_socket.ex
+++ b/fjord/lib/fjord_web/channels/user_socket.ex
@@ -15,11 +15,11 @@ defmodule FjordWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(%{"username" => username}, socket) do
+  def connect(%{"username" => username}, socket, _conn_info) do
     {:ok, assign(socket, :username, username)}
   end
 
-  def connect(_params, socket) do
+  def connect(params, socket, _conn_info) do
     {:ok, assign(socket, :username, "anonymous")}
   end
 


### PR DESCRIPTION
resolves #43 

We were sending the username on the channel join, but not on the original connection and that's when the socket gets assigned.